### PR TITLE
Placeholder regex match is too greedy

### DIFF
--- a/lib/fluent/plugin/out_statsd.rb
+++ b/lib/fluent/plugin/out_statsd.rb
@@ -95,7 +95,7 @@ module Fluent
 
       def parse(string)
         return unless string
-        string.gsub(/\$\{.+\}/) {|str| @obj.instance_eval str[2..-2] }
+        string.gsub(/\$\{[^\}]+\}/) {|str| @obj.instance_eval str[2..-2] }
       end
     end
   end

--- a/spec/plugin/multiple_placeholders_spec.rb
+++ b/spec/plugin/multiple_placeholders_spec.rb
@@ -1,0 +1,55 @@
+require 'fluent/plugin/out_statsd'
+require 'fluent/test'
+
+RSpec.describe Fluent::StatsdOutput do
+  let(:config) do
+    %{
+      type statsd
+
+      <metric>
+        statsd_type increment
+        statsd_key res_code_${record['hostname']}_${record['status'].to_i / 100}xx
+      </metric>
+    }
+  end
+  let(:driver) { create_driver(config) }
+  let(:statsd) { double('statsd', increment: true,
+                                  flush: true,
+                                  'namespace=' => true,
+                                  'batch_size=' => true,
+                                  'batch_byte_size' => true)
+
+               }
+  let(:time) { Time.now.utc }
+
+  before :all do
+    Fluent::Test.setup
+  end
+
+  def create_driver(conf)
+    Fluent::Test::BufferedOutputTestDriver.new(Fluent::StatsdOutput) {
+    }.configure(conf)
+  end
+
+  def emit_events(events)
+    events.each {|e| driver.emit(e, time) }
+  end
+
+
+  it 'should call statsd with events data and correctly handle multiple placeholders' do
+    allow(Statsd).to receive(:new).and_return(statsd)
+
+    expect(statsd).to receive(:increment).with('res_code_localhost_2xx').twice.times
+    expect(statsd).to receive(:increment).with('res_code_localhost_4xx').once.times
+    expect(statsd).to receive(:increment).with('res_code_localhost_5xx').once.times
+
+    emit_events([
+      {'hostname' => 'localhost', 'response_time' => 102, 'status' => '200'},
+      {'hostname' => 'localhost', 'response_time' => 105, 'status' => '200'},
+      {'hostname' => 'localhost', 'response_time' => 112, 'status' => '400'},
+      {'hostname' => 'localhost', 'response_time' => 125, 'status' => '500'}
+    ])
+
+    driver.run
+  end
+end


### PR DESCRIPTION
Currently, `RubyStringParser` is too greedy, and its match will treat multiple placeholders as a single continuous string.

For example, if you provide a key of `something_${record['hostname']}_${record['process_id']}`, the current logic will look for a placeholder named `record['hostname']}_${record['process_id']`.

It should instead look for `record['hostname']` and `record['process_id']` separately, as two different placeholders.

This patch changes the regular expression to be less greedy, by looking for anything up to the first occurrence of a closing curly brace.