### PR TITLE
Add Sampling rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,13 @@ $ fluent-gem install fluent-plugin-statsd-output
   port 8125 # optional
   namespace a.b.c # optional
   batch_byte_size 512 # optional
+  sample_rate 0.9 # optional
 
   <metric>
     statsd_type timing
     statsd_key my_app.nginx.response_time
     statsd_val ${record['response_time']}
+    statsd_rate 0.6 # optional
   </metric>
 
   <metric>

--- a/spec/plugin/multiple_placeholders_spec.rb
+++ b/spec/plugin/multiple_placeholders_spec.rb
@@ -39,9 +39,9 @@ RSpec.describe Fluent::StatsdOutput do
   it 'should call statsd with events data and correctly handle multiple placeholders' do
     allow(Statsd).to receive(:new).and_return(statsd)
 
-    expect(statsd).to receive(:increment).with('res_code_localhost_2xx').twice.times
-    expect(statsd).to receive(:increment).with('res_code_localhost_4xx').once.times
-    expect(statsd).to receive(:increment).with('res_code_localhost_5xx').once.times
+    expect(statsd).to receive(:increment).with('res_code_localhost_2xx', sample_rate: 1.0).twice.times
+    expect(statsd).to receive(:increment).with('res_code_localhost_4xx', sample_rate: 1.0).once.times
+    expect(statsd).to receive(:increment).with('res_code_localhost_5xx', sample_rate: 1.0).once.times
 
     emit_events([
       {'hostname' => 'localhost', 'response_time' => 102, 'status' => '200'},

--- a/spec/plugin/statsd_rate_override.rb
+++ b/spec/plugin/statsd_rate_override.rb
@@ -12,11 +12,7 @@ RSpec.describe Fluent::StatsdOutput do
         statsd_type timing
         statsd_key res_time
         statsd_val ${record['response_time']}
-      </metric>
-
-      <metric>
-        statsd_type increment
-        statsd_key res_code_${record['status'].to_i / 100}xx
+        statsd_rate 0.4
       </metric>
     }
   end
@@ -52,13 +48,10 @@ RSpec.describe Fluent::StatsdOutput do
     expect(statsd).to receive(:batch_size=).with(nil)
     expect(statsd).to receive(:batch_byte_size=).with(512)
 
-    expect(statsd).to receive(:increment).with('res_code_2xx', sample_rate: 1.0).twice.times
-    expect(statsd).to receive(:increment).with('res_code_4xx', sample_rate: 1.0).once.times
-    expect(statsd).to receive(:increment).with('res_code_5xx', sample_rate: 1.0).once.times
-    expect(statsd).to receive(:timing).with('res_time', 102, sample_rate: 1.0).ordered
-    expect(statsd).to receive(:timing).with('res_time', 105, sample_rate: 1.0).ordered
-    expect(statsd).to receive(:timing).with('res_time', 112, sample_rate: 1.0).ordered
-    expect(statsd).to receive(:timing).with('res_time', 125, sample_rate: 1.0).ordered
+    expect(statsd).to receive(:timing).with('res_time', 102, sample_rate: 0.4).ordered
+    expect(statsd).to receive(:timing).with('res_time', 105, sample_rate: 0.4).ordered
+    expect(statsd).to receive(:timing).with('res_time', 112, sample_rate: 0.4).ordered
+    expect(statsd).to receive(:timing).with('res_time', 125, sample_rate: 0.4).ordered
 
     emit_events([
       {'response_time' => 102, 'status' => '200'},


### PR DESCRIPTION
Adds a sampling rate configuration value and per-record value. Helpful if you're getting too many hits to your metric and want to keep statsd/graphite happy.